### PR TITLE
Linking 'python' to 'python3' for cross-compatibility

### DIFF
--- a/Install-Dependencies.bat
+++ b/Install-Dependencies.bat
@@ -270,6 +270,7 @@ setlocal enabledelayedexpansion
     (
         python3 --version >nul 2>&1
     ) && (
+        endlocal
         call :PrintInfo "python3 is linked properly"
         REM No need to create a symlink if python3 is already working
         goto :installPythonStuff

--- a/Open_Terminal_Here.bat
+++ b/Open_Terminal_Here.bat
@@ -1,0 +1,1 @@
+start cmd /k cd /d "%~dp0"


### PR DESCRIPTION
Added logic to check and create a symlink for 'python3' to ensure scripts can be invoked using both 'python' and 'python3' commands. This guarantees compatibility across environments where 'python3' is required. Helps avoid potential confusion and errors in script execution.

Added a script to open a new Terminal with cwd of the current folder.

Only been able to do limited testing.
Tested on Win11 and Wind10 once, both ran without an issue.